### PR TITLE
Increase platforms compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-runtime",
       "state" : {
-        "revision" : "b66f94a30a25330635f3e5e064245acfd92ff5a2",
-        "version" : "0.1.2"
+        "revision" : "02ae849d3ed0905d467b13c9056658ca383c9749",
+        "version" : "0.1.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "swift-openapi-request-dl",
-    platforms: [.macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9)],
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     products: [
         .library(
             name: "OpenAPIRequestDL",
@@ -19,7 +19,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-openapi-runtime",
-            from: "0.1.2"
+            from: "0.1.3"
         ),
         .package(
             url: "https://github.com/apple/swift-docc-plugin",


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

Improve platform compatibility by updating the OpenAPIRuntime version to `0.1.3`, which adds support for macOS 10.15, iOS 13, tvOS 13, and watchOS 6.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] All new and existing tests passed.
