### PR TITLE
ci: enable Android cross-compile build step

### DIFF
--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -60,6 +60,9 @@ jobs:
       # Step 3 – Linkage Test (renomeado de test-foundation-essentials)
       enable-linkage-test: true
 
+      # Step 3 – Android Build
+      enable-android-build: true
+
       # Step 4
       enable-coverage-upload: true
     secrets: inherit

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/request-dl/request-dl-nio.git",
-            exact: "4.0.3"
+            exact: "4.1.0"
         ),
         .package(
             url: "https://github.com/apple/swift-openapi-runtime",


### PR DESCRIPTION
## Summary
- Opts into the new `android-build` job from the shared `swift-ci.yaml` reusable workflow (request-dl/.github#93) by setting `enable-android-build: true`.
- Cross-compiles this package for Android (`aarch64-unknown-linux-android28`) on every push/PR to `main`, build-only.

## Dependency
This calls `uses: request-dl/.github/.github/workflows/swift-ci.yaml@main`, so CI on this PR won't pick up the new `android-build` job (and may fail on the unrecognized `enable-android-build` input) until request-dl/.github#93 is merged to `main` first.

## Test plan
- [ ] Merge request-dl/.github#93 first
- [ ] Confirm `android-build` job runs and passes in this PR's CI